### PR TITLE
脚注関連のshortcodeとrenderhookを別モジュールへ移動

### DIFF
--- a/layouts/_default/_markup/render-codeblock-footnotes.html
+++ b/layouts/_default/_markup/render-codeblock-footnotes.html
@@ -1,6 +1,0 @@
-<div class="footnotes" role="doc-endnotes">
-  <hr />
-  <ol class="list-disc list-outside">
-    {{- .Inner | markdownify }}
-  </ol>
-</div>

--- a/layouts/shortcodes/fn.html
+++ b/layouts/shortcodes/fn.html
@@ -1,2 +1,0 @@
-{{- $fn := .Get 0 -}}
-<sup class="mr-1" id="fnref:{{ $fn }}"><a href="#fn:{{ $fn }}" class="footnote-ref" role="doc-noteref">[{{ $fn }}]</a></sup>

--- a/layouts/shortcodes/fnote.html
+++ b/layouts/shortcodes/fnote.html
@@ -1,4 +1,0 @@
-{{- $fn := .Get 0 -}}
-<li id="fn:{{ $fn }}">
-    <p><span class="mr-1">[{{ $fn }}]:</span>{{ .Inner | markdownify }}&nbsp;<a href="#fnref:{{ $fn }}" class="footnote-backref" role="doc-backlink">↩︎</a></p>
-</li>


### PR DESCRIPTION
以下に専用モジュールを作成

[kantas-spike/my-shortcodes: Hugoで使用するショートコードやレンダーフックをまとめたモジュールです。](https://github.com/kantas-spike/my-shortcodes)